### PR TITLE
Add support for reading .npmrc during add command

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,4 +392,13 @@ async function merge({roots, out}) {
   await write(`${out}/yarn.lock`, lockfile.stringify(lock), 'utf8');
 }
 
-module.exports = {add, upgrade, remove, optimize, sync, check, merge};
+module.exports = {
+  add,
+  upgrade,
+  remove,
+  optimize,
+  sync,
+  check,
+  merge,
+  readNpmrc,
+};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const proc = require('child_process');
+const {resolve} = require('path');
 const {promisify} = require('util');
 const {readFile, writeFile, access} = require('fs');
 const lockfile = require('@yarnpkg/lockfile');
@@ -9,20 +10,25 @@ const exec = (cmd, args = {}) => {
     proc.exec(cmd, args, (err, stdout, stderr) => {
       if (err) reject(err);
       else resolve(stdout);
-    })
+    });
   });
 };
 const accessFile = promisify(access);
-const exists = filename => accessFile(filename).then(() => true).catch(() => false);
+const exists = filename =>
+  accessFile(filename)
+    .then(() => true)
+    .catch(() => false);
 const read = promisify(readFile);
 const write = promisify(writeFile);
 
 // helpers
 function sort(unordered) {
   const ordered = {};
-  Object.keys(unordered).sort().forEach(function(key) {
-    ordered[key] = unordered[key];
-  });
+  Object.keys(unordered)
+    .sort()
+    .forEach(function(key) {
+      ordered[key] = unordered[key];
+    });
   return ordered;
 }
 
@@ -70,6 +76,33 @@ async function containing(dirs, files) {
 }
 
 // API
+const readNpmrc = async dir => {
+  const npmrcs = await findNpmrcs(dir);
+  const configs = npmrcs.map(npmrc => {
+    return npmrc
+      .replace(/[#;].*[\r\n]/gm, '')
+      .split('\n')
+      .reduce((memo, line) => {
+        const [key, ...rest] = line.split('=');
+        // TODO handle `key[] = value` syntax
+        if (key) {
+          memo[key.trim()] = rest
+            .join('=')
+            .replace(/\$\{([^}]+)\}/g, (match, key) => process.env[key]);
+        }
+        return memo;
+      }, {});
+  });
+  return Object.assign({}, ...configs.reverse());
+};
+
+const findNpmrcs = async dir => {
+  const npmrcs = [await read(`${dir}/.npmrc`, 'utf8').catch(() => '')];
+  if (resolve(`${dir}/..`) !== '/')
+    npmrcs.push(...(await findNpmrcs(`${dir}/..`)));
+  return npmrcs;
+};
+
 async function add({roots, dep, version, type = 'dependencies', tmp = '/tmp'}) {
   tmp = `${tmp}/yarn-utils-${Math.random() * 1e17}`;
 
@@ -78,22 +111,44 @@ async function add({roots, dep, version, type = 'dependencies', tmp = '/tmp'}) {
       return JSON.parse(await read(`${root}/package.json`, 'utf8'));
     })
   );
-  const resolutions = metas.reduce((memo, meta) => ({...memo, ...meta.resolutions}), {});
+  const configs = await Promise.all(
+    roots.map(async root => {
+      return await readNpmrc(root);
+    })
+  );
+  const resolutions = metas.reduce(
+    (memo, meta) => ({...memo, ...meta.resolutions}),
+    {}
+  );
 
   await exec(`mkdir -p ${tmp}`);
+  await write(
+    `${tmp}/.npmrc`,
+    Object.keys(configs)
+      .map(key => `${key}=${configs[key]}`)
+      .join('\n')
+  );
   await write(`${tmp}/package.json`, JSON.stringify({resolutions}));
-  await exec(`yarn add ${dep}${version ? `@${version}` : ''} --cwd ${tmp} 2>/dev/null`);
-  version = JSON.parse(await read(`${tmp}/package.json`, 'utf8')).dependencies[dep];
+  await exec(
+    `yarn add ${dep}${version ? `@${version}` : ''} --cwd ${tmp} 2>/dev/null`
+  );
+  version = JSON.parse(await read(`${tmp}/package.json`, 'utf8')).dependencies[
+    dep
+  ];
   const added = lockfile.parse(await read(`${tmp}/yarn.lock`, 'utf8'));
   await exec(`rm -rf ${tmp}`);
 
   return Promise.all(
     roots.map(async (root, i) => {
       const meta = metas[i];
-      if (meta.dependencies && meta.dependencies[dep]) meta.dependencies[dep] = version;
-      if (meta.devDependencies && meta.devDependencies[dep]) meta.devDependencies[dep] = version;
-      if (meta.peerDependencies && meta.peerDependencies[dep]) meta.peerDependencies[dep] = version;
-      if (meta.optionalDependencies && meta.optionalDependencies[dep]) meta.optionalDependencies[dep] = version;
+      if (meta.dependencies && meta.dependencies[dep])
+        meta.dependencies[dep] = version;
+      if (meta.devDependencies && meta.devDependencies[dep])
+        meta.devDependencies[dep] = version;
+      if (meta.peerDependencies && meta.peerDependencies[dep])
+        meta.peerDependencies[dep] = version;
+      if (meta.optionalDependencies && meta.optionalDependencies[dep])
+        meta.optionalDependencies[dep] = version;
       if (!meta[type]) meta[type] = {};
       meta[type][dep] = version;
       await write(`${root}/package.json`, JSON.stringify(meta, null, 2));
@@ -110,18 +165,26 @@ async function upgrade({roots, dep, version, tmp = '/tmp'}) {
   tmp = `${tmp}/yarn-utils-${Math.random() * 1e17}`;
   await exec(`mkdir -p ${tmp}`);
   await write(`${tmp}/package.json`, '{}');
-  await exec(`yarn add ${dep}${version ? `@${version}` : ''} --cwd ${tmp} 2>/dev/null`);
-  version = JSON.parse(await read(`${tmp}/package.json`, 'utf8')).dependencies[dep];
+  await exec(
+    `yarn add ${dep}${version ? `@${version}` : ''} --cwd ${tmp} 2>/dev/null`
+  );
+  version = JSON.parse(await read(`${tmp}/package.json`, 'utf8')).dependencies[
+    dep
+  ];
   const added = lockfile.parse(await read(`${tmp}/yarn.lock`, 'utf8'));
   await exec(`rm -rf ${tmp}`);
 
   return Promise.all(
     roots.map(async root => {
       const meta = JSON.parse(await read(`${root}/package.json`, 'utf8'));
-      if (meta.dependencies && meta.dependencies[dep]) meta.dependencies[dep] = version;
-      if (meta.devDependencies && meta.devDependencies[dep]) meta.devDependencies[dep] = version;
-      if (meta.peerDependencies && meta.peerDependencies[dep]) meta.peerDependencies[dep] = version;
-      if (meta.optionalDependencies && meta.optionalDependencies[dep]) meta.optionalDependencies[dep] = version;
+      if (meta.dependencies && meta.dependencies[dep])
+        meta.dependencies[dep] = version;
+      if (meta.devDependencies && meta.devDependencies[dep])
+        meta.devDependencies[dep] = version;
+      if (meta.peerDependencies && meta.peerDependencies[dep])
+        meta.peerDependencies[dep] = version;
+      if (meta.optionalDependencies && meta.optionalDependencies[dep])
+        meta.optionalDependencies[dep] = version;
       await write(`${root}/package.json`, JSON.stringify(meta, null, 2));
 
       const f = lockfile.parse(await read(`${root}/yarn.lock`, 'utf8'));
@@ -137,10 +200,14 @@ async function remove({roots, dep}) {
     roots.map(async root => {
       const meta = JSON.parse(await read(`${root}/package.json`, 'utf8'));
 
-      if (meta.dependencies && meta.dependencies[dep]) delete meta.dependencies[dep];
-      if (meta.devDependencies && meta.devDependencies[dep]) delete meta.devDependencies[dep];
-      if (meta.peerDependencies && meta.peerDependencies[dep]) delete meta.peerDependencies[dep];
-      if (meta.optionalDependencies && meta.optionalDependencies[dep]) delete meta.optionalDependencies[dep];
+      if (meta.dependencies && meta.dependencies[dep])
+        delete meta.dependencies[dep];
+      if (meta.devDependencies && meta.devDependencies[dep])
+        delete meta.devDependencies[dep];
+      if (meta.peerDependencies && meta.peerDependencies[dep])
+        delete meta.peerDependencies[dep];
+      if (meta.optionalDependencies && meta.optionalDependencies[dep])
+        delete meta.optionalDependencies[dep];
       await write(`${root}/package.json`, JSON.stringify(meta, null, 2));
 
       const f = lockfile.parse(await read(`${root}/yarn.lock`, 'utf8'));
@@ -167,7 +234,10 @@ async function optimize({roots}) {
       const dep = d.lockfile.object[key];
       const [, name, version] = key.match(/^(.+?)@(.+?)$/);
       if (!versions[name]) versions[name] = {};
-      if (!versions[name][version] || semver.gt(dep.version, versions[name][version].version)) {
+      if (
+        !versions[name][version] ||
+        semver.gt(dep.version, versions[name][version].version)
+      ) {
         versions[name][version] = dep;
 
         function collect(key, deps = {}) {
@@ -188,17 +258,22 @@ async function optimize({roots}) {
   Object.keys(versions).forEach(name => {
     Object.keys(versions[name]).forEach(key => {
       Object.keys(versions[name]).forEach(version => {
-        const actualName = key.startsWith('npm:') ? key.match(/npm:(.[^@]*)/)[1] : name;
+        const actualName = key.startsWith('npm:')
+          ? key.match(/npm:(.[^@]*)/)[1]
+          : name;
         if (
           name === actualName &&
           semver.satisfies(versions[name][key].version, version) &&
-          semver.gte(versions[name][key].version, versions[name][version].version)
+          semver.gte(
+            versions[name][key].version,
+            versions[name][version].version
+          )
         ) {
-          versions[name][version] = versions[name][key]
+          versions[name][version] = versions[name][key];
         }
-      })
-    })
-  })
+      });
+    });
+  });
 
   Object.keys(versions).forEach(name => {
     Object.keys(versions[name]).forEach(version => {
@@ -209,7 +284,10 @@ async function optimize({roots}) {
           Object.keys(newDeps[key]).forEach(depKey => {
             if (
               !d.lockfile.object[depKey] ||
-              semver.lt(d.lockfile.object[depKey].version, newDeps[key][depKey].version)
+              semver.lt(
+                d.lockfile.object[depKey].version,
+                newDeps[key][depKey].version
+              )
             ) {
               d.lockfile.object[depKey] = newDeps[key][depKey];
             }
@@ -230,19 +308,24 @@ async function optimize({roots}) {
 
 async function sync({roots, ignore = [], tmp}) {
   const addAll = async (root, meta, object, type, ignore) => {
-    const names = Object.keys(meta[type] || {})
-      .filter(name => {
-        const needsDownload = !object[`${name}@${meta[type][name]}`];
-        const shouldDownload = !ignore.find(ignored => ignored === name);
-        return needsDownload && shouldDownload;
-      });
+    const names = Object.keys(meta[type] || {}).filter(name => {
+      const needsDownload = !object[`${name}@${meta[type][name]}`];
+      const shouldDownload = !ignore.find(ignored => ignored === name);
+      return needsDownload && shouldDownload;
+    });
     for (const name of names) {
-      await add({roots: [root], dep: name, version: meta[type][name], type, tmp})
+      await add({
+        roots: [root],
+        dep: name,
+        version: meta[type][name],
+        type,
+        tmp,
+      });
     }
-  }
+  };
   return Promise.all(
     roots.map(async root => {
-      if (!await exists(`${root}/yarn.lock`)) {
+      if (!(await exists(`${root}/yarn.lock`))) {
         await write(`${root}/yarn.lock`, '', 'utf8');
       }
       const meta = JSON.parse(await read(`${root}/package.json`, 'utf8'));
@@ -265,7 +348,7 @@ async function check({roots}) {
     });
   }
 
-  const dirs = await containing(roots, ['package.json'])
+  const dirs = await containing(roots, ['package.json']);
   await Promise.all(
     dirs.map(async dir => {
       const meta = JSON.parse(await read(`${dir}/package.json`, 'utf8'));
@@ -301,7 +384,11 @@ async function merge({roots, out}) {
   );
 
   await exec(`mkdir -p ${out}`);
-  await write(`${out}/package.json`, JSON.stringify({dependencies: deps, resolutions}, null, 2), 'utf8');
+  await write(
+    `${out}/package.json`,
+    JSON.stringify({dependencies: deps, resolutions}, null, 2),
+    'utf8'
+  );
   await write(`${out}/yarn.lock`, lockfile.stringify(lock), 'utf8');
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,14 +2,22 @@ const assert = require('assert');
 const proc = require('child_process');
 const {promisify} = require('util');
 const {writeFile, readFile} = require('fs');
-const {add, upgrade, remove, optimize, sync, check, merge} = require('../index.js');
+const {
+  add,
+  upgrade,
+  remove,
+  optimize,
+  sync,
+  check,
+  merge,
+} = require('../index.js');
 
 const exec = cmd => {
   return new Promise((resolve, reject) => {
     proc.exec(cmd, (err, stdout, stderr) => {
       if (err) reject(err);
       else resolve(stdout);
-    })
+    });
   });
 };
 const read = promisify(readFile);
@@ -18,7 +26,6 @@ const write = promisify(writeFile);
 run();
 
 async function run() {
-
   await exec(`rm -rf ${__dirname}/tmp && mkdir -p ${__dirname}/tmp`);
 
   // add works
@@ -26,77 +33,233 @@ async function run() {
   await write(`${__dirname}/tmp/add/package.json`, '{}');
   await write(`${__dirname}/tmp/add/yarn.lock`, '');
   await add({roots: [`${__dirname}/tmp/add`], dep: 'has', version: '1.0.3'});
-  assert((await read(`${__dirname}/tmp/add/package.json`, 'utf8')).includes('"has": "1.0.3"'))
-  assert((await read(`${__dirname}/tmp/add/yarn.lock`, 'utf8')).includes('function-bind@^1.1.1'))
+  assert(
+    (await read(`${__dirname}/tmp/add/package.json`, 'utf8')).includes(
+      '"has": "1.0.3"'
+    )
+  );
+  assert(
+    (await read(`${__dirname}/tmp/add/yarn.lock`, 'utf8')).includes(
+      'function-bind@^1.1.1'
+    )
+  );
+
+  // add works with npmrc
+  await exec(`mkdir -p ${__dirname}/tmp/add-npmrc`);
+  await write(`${__dirname}/tmp/add-npmrc/package.json`, '{}');
+  await write(`${__dirname}/tmp/add-npmrc/yarn.lock`, '');
+  await write(
+    `${__dirname}/tmp/add-npmrc/.npmrc`,
+    'registry=https://registry.yarnpkg.com'
+  );
+  await add({
+    roots: [`${__dirname}/tmp/add-npmrc`],
+    dep: 'has',
+    version: '1.0.3',
+  });
+  assert(
+    (await read(`${__dirname}/tmp/add-npmrc/package.json`, 'utf8')).includes(
+      '"has": "1.0.3"'
+    )
+  );
+  assert(
+    (await read(`${__dirname}/tmp/add-npmrc/yarn.lock`, 'utf8')).includes(
+      'https://registry.yarnpkg.com'
+    )
+  );
+
+  // add with npmrc works
+  await exec(`mkdir -p ${__dirname}/tmp/add`);
+  await write(`${__dirname}/tmp/add/package.json`, '{}');
+  await write(`${__dirname}/tmp/add/yarn.lock`, '');
+  await add({roots: [`${__dirname}/tmp/add`], dep: 'has', version: '1.0.3'});
+  assert(
+    (await read(`${__dirname}/tmp/add/package.json`, 'utf8')).includes(
+      '"has": "1.0.3"'
+    )
+  );
+  assert(
+    (await read(`${__dirname}/tmp/add/yarn.lock`, 'utf8')).includes(
+      'function-bind@^1.1.1'
+    )
+  );
 
   // upgrade works
   await exec(`mkdir -p ${__dirname}/tmp/upgrade`);
-  await write(`${__dirname}/tmp/upgrade/package.json`, '{"dependencies": {"has": "0.0.1"}}');
+  await write(
+    `${__dirname}/tmp/upgrade/package.json`,
+    '{"dependencies": {"has": "0.0.1"}}'
+  );
   await write(`${__dirname}/tmp/upgrade/yarn.lock`, '');
-  await upgrade({roots: [`${__dirname}/tmp/upgrade`], dep: 'has', version: '1.0.3'});
-  assert((await read(`${__dirname}/tmp/upgrade/package.json`, 'utf8')).includes('"has": "1.0.3"'));
-  assert((await read(`${__dirname}/tmp/upgrade/yarn.lock`, 'utf8')).includes('function-bind@^1.1.1'));
+  await upgrade({
+    roots: [`${__dirname}/tmp/upgrade`],
+    dep: 'has',
+    version: '1.0.3',
+  });
+  assert(
+    (await read(`${__dirname}/tmp/upgrade/package.json`, 'utf8')).includes(
+      '"has": "1.0.3"'
+    )
+  );
+  assert(
+    (await read(`${__dirname}/tmp/upgrade/yarn.lock`, 'utf8')).includes(
+      'function-bind@^1.1.1'
+    )
+  );
 
   await exec(`mkdir -p ${__dirname}/tmp/dont-upgrade`);
-  await write(`${__dirname}/tmp/dont-upgrade/package.json`, '{"dependencies": {}}');
+  await write(
+    `${__dirname}/tmp/dont-upgrade/package.json`,
+    '{"dependencies": {}}'
+  );
   await write(`${__dirname}/tmp/dont-upgrade/yarn.lock`, '');
-  await upgrade({roots: [`${__dirname}/tmp/dont-upgrade`], dep: 'has', version: '1.0.3'});
-  assert(!(await read(`${__dirname}/tmp/dont-upgrade/package.json`, 'utf8')).includes('"has"'));
+  await upgrade({
+    roots: [`${__dirname}/tmp/dont-upgrade`],
+    dep: 'has',
+    version: '1.0.3',
+  });
+  assert(
+    !(await read(
+      `${__dirname}/tmp/dont-upgrade/package.json`,
+      'utf8'
+    )).includes('"has"')
+  );
 
   // remove works
   await exec(`cp -r ${__dirname}/fixtures/remove ${__dirname}/tmp/remove`);
   await remove({roots: [`${__dirname}/tmp/remove`], dep: 'has'});
-  assert((await read(`${__dirname}/tmp/remove/package.json`, 'utf8')).includes('{}'));
-  assert((await read(`${__dirname}/tmp/remove/yarn.lock`, 'utf8')).includes('function-bind') === false);
+  assert(
+    (await read(`${__dirname}/tmp/remove/package.json`, 'utf8')).includes('{}')
+  );
+  assert(
+    (await read(`${__dirname}/tmp/remove/yarn.lock`, 'utf8')).includes(
+      'function-bind'
+    ) === false
+  );
 
   // optimize works
   await exec(`cp -r ${__dirname}/fixtures/optimize ${__dirname}/tmp/optimize`);
-  await optimize({roots: [`${__dirname}/tmp/optimize/a`, `${__dirname}/tmp/optimize/b`]});
-  assert((await read(`${__dirname}/tmp/optimize/b/yarn.lock`, 'utf8')).includes('function-bind@^1.1.2'));
-  assert((await read(`${__dirname}/tmp/optimize/b/yarn.lock`, 'utf8')).includes('function-bind@^1.1.1') === false);
+  await optimize({
+    roots: [`${__dirname}/tmp/optimize/a`, `${__dirname}/tmp/optimize/b`],
+  });
+  assert(
+    (await read(`${__dirname}/tmp/optimize/b/yarn.lock`, 'utf8')).includes(
+      'function-bind@^1.1.2'
+    )
+  );
+  assert(
+    (await read(`${__dirname}/tmp/optimize/b/yarn.lock`, 'utf8')).includes(
+      'function-bind@^1.1.1'
+    ) === false
+  );
 
   // optimize's deduping works
   await exec(`cp -r ${__dirname}/fixtures/dedupe ${__dirname}/tmp/dedupe`);
   await optimize({roots: [`${__dirname}/tmp/dedupe/a`]});
-  assert((await read(`${__dirname}/tmp/dedupe/a/yarn.lock`, 'utf8')).includes('function-bind@^1.1.1, function-bind@^1.1.2'));
+  assert(
+    (await read(`${__dirname}/tmp/dedupe/a/yarn.lock`, 'utf8')).includes(
+      'function-bind@^1.1.1, function-bind@^1.1.2'
+    )
+  );
 
   // sync works
   await exec(`cp -r ${__dirname}/fixtures/sync ${__dirname}/tmp/sync`);
   await sync({roots: [`${__dirname}/tmp/sync`]});
-  assert((await read(`${__dirname}/tmp/sync/yarn.lock`, 'utf8')).includes('no-bugs@1.0.0'));
-  assert((await read(`${__dirname}/tmp/sync/yarn.lock`, 'utf8')).includes('function-bind@^1.1.1'));
+  assert(
+    (await read(`${__dirname}/tmp/sync/yarn.lock`, 'utf8')).includes(
+      'no-bugs@1.0.0'
+    )
+  );
+  assert(
+    (await read(`${__dirname}/tmp/sync/yarn.lock`, 'utf8')).includes(
+      'function-bind@^1.1.1'
+    )
+  );
 
   // sync works with missing yarn.lock
   await exec(`cp -r ${__dirname}/fixtures/regen ${__dirname}/tmp/regen`);
   await sync({roots: [`${__dirname}/tmp/regen`]});
-  assert((await read(`${__dirname}/tmp/regen/yarn.lock`, 'utf8')).includes('no-bugs@1.0.0'));
-  assert((await read(`${__dirname}/tmp/regen/yarn.lock`, 'utf8')).includes('function-bind@^1.1.1'));
+  assert(
+    (await read(`${__dirname}/tmp/regen/yarn.lock`, 'utf8')).includes(
+      'no-bugs@1.0.0'
+    )
+  );
+  assert(
+    (await read(`${__dirname}/tmp/regen/yarn.lock`, 'utf8')).includes(
+      'function-bind@^1.1.1'
+    )
+  );
 
   // sync works with `ignore` list
-  await exec(`cp -r ${__dirname}/fixtures/sync-with-ignore ${__dirname}/tmp/sync-with-ignore`);
-  await sync({roots: [`${__dirname}/tmp/sync-with-ignore`], ignore: ['no-bugs']});
-  assert(!(await read(`${__dirname}/tmp/sync-with-ignore/yarn.lock`, 'utf8')).includes('no-bugs@1.0.0'));
-  assert((await read(`${__dirname}/tmp/sync-with-ignore/yarn.lock`, 'utf8')).includes('function-bind@^1.1.1'));
+  await exec(
+    `cp -r ${__dirname}/fixtures/sync-with-ignore ${__dirname}/tmp/sync-with-ignore`
+  );
+  await sync({
+    roots: [`${__dirname}/tmp/sync-with-ignore`],
+    ignore: ['no-bugs'],
+  });
+  assert(
+    !(await read(
+      `${__dirname}/tmp/sync-with-ignore/yarn.lock`,
+      'utf8'
+    )).includes('no-bugs@1.0.0')
+  );
+  assert(
+    (await read(
+      `${__dirname}/tmp/sync-with-ignore/yarn.lock`,
+      'utf8'
+    )).includes('function-bind@^1.1.1')
+  );
 
   // sync works with resolution
-  await exec(`cp -r ${__dirname}/fixtures/sync-with-resolution ${__dirname}/tmp/sync-with-resolution`);
+  await exec(
+    `cp -r ${__dirname}/fixtures/sync-with-resolution ${__dirname}/tmp/sync-with-resolution`
+  );
   await sync({roots: [`${__dirname}/tmp/sync-with-resolution`]});
-  assert((await read(`${__dirname}/tmp/sync-with-resolution/yarn.lock`, 'utf8')).includes('function-bind@^1.0.0'));
-  assert((await read(`${__dirname}/tmp/sync-with-resolution/yarn.lock`, 'utf8')).includes('function-bind@^1.1.1'));
+  assert(
+    (await read(
+      `${__dirname}/tmp/sync-with-resolution/yarn.lock`,
+      'utf8'
+    )).includes('function-bind@^1.0.0')
+  );
+  assert(
+    (await read(
+      `${__dirname}/tmp/sync-with-resolution/yarn.lock`,
+      'utf8'
+    )).includes('function-bind@^1.1.1')
+  );
 
   // check works
   await exec(`cp -r ${__dirname}/fixtures/check ${__dirname}/tmp/check`);
-  const {has} = await check({roots: [`${__dirname}/tmp/check/a`, `${__dirname}/tmp/check/b`]});
+  const {has} = await check({
+    roots: [`${__dirname}/tmp/check/a`, `${__dirname}/tmp/check/b`],
+  });
   assert.equal(Object.keys(has).length, 2);
 
   // merge works
-  await exec(`cp -r ${__dirname}/fixtures/merge ${__dirname}/tmp/merge && rm -rf ${__dirname}/tmp/merge/merged`);
-  await merge({roots: [`${__dirname}/tmp/merge/a`, `${__dirname}/tmp/merge/b`], out: `${__dirname}/tmp/merge/merged`});
-  assert((await read(`${__dirname}/tmp/merge/merged/package.json`, 'utf8')).includes('resolutions'));
-  assert((await read(`${__dirname}/tmp/merge/merged/yarn.lock`, 'utf8')).includes('function-bind@^1.1.1'));
-  assert((await read(`${__dirname}/tmp/merge/merged/yarn.lock`, 'utf8')).includes('no-bugs@1.0.0'));
+  await exec(
+    `cp -r ${__dirname}/fixtures/merge ${__dirname}/tmp/merge && rm -rf ${__dirname}/tmp/merge/merged`
+  );
+  await merge({
+    roots: [`${__dirname}/tmp/merge/a`, `${__dirname}/tmp/merge/b`],
+    out: `${__dirname}/tmp/merge/merged`,
+  });
+  assert(
+    (await read(`${__dirname}/tmp/merge/merged/package.json`, 'utf8')).includes(
+      'resolutions'
+    )
+  );
+  assert(
+    (await read(`${__dirname}/tmp/merge/merged/yarn.lock`, 'utf8')).includes(
+      'function-bind@^1.1.1'
+    )
+  );
+  assert(
+    (await read(`${__dirname}/tmp/merge/merged/yarn.lock`, 'utf8')).includes(
+      'no-bugs@1.0.0'
+    )
+  );
 
   await exec(`rm -rf ${__dirname}/tmp`);
   console.log('Tests passed');
-
 }


### PR DESCRIPTION
* Imports helpers from jazelle into yarn-utilities to read .npmrc files.
* Generate a .npmrc configuration file from all roots when adding.